### PR TITLE
feat: improve auth context handling in MCP server

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/src/handlers/mcpServer.ts
+++ b/src/handlers/mcpServer.ts
@@ -53,7 +53,7 @@ export function createMcpServerHandler(
     const server = new McpServer(config, { capabilities: config.capabilities });
 
     // Get auth info from the authenticated request
-    const authInfo = (req as Request & { authInfo?: AuthInfo }).authInfo;
+    const authInfo = (req as Request & { auth?: AuthInfo }).auth;
 
     // Attach request context to the server for this request lifecycle
     if (authInfo) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,7 +163,7 @@ export function registerAuthenticatedTool(
       args: unknown,
       extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
     ) => {
-      // Get request context from the server
+      // Get auth context from the server
       const context = getRequestContext(server as ServerWithContext);
 
       if (!context?.authInfo) {

--- a/src/utils/outboundToken.ts
+++ b/src/utils/outboundToken.ts
@@ -86,12 +86,20 @@ export async function getOutboundToken(
     const descopeClient = createAuthenticatedDescopeClient(config, userToken);
 
     // Use the new outbound token exchange API from the next version
-    const result =
-      await descopeClient.management.outboundApplication.fetchTokenByScopes(
+    let result;
+    if (scopes && scopes.length > 0) {
+      result =
+        await descopeClient.management.outboundApplication.fetchTokenByScopes(
+          appId,
+          userId,
+          scopes || [],
+        );
+    } else {
+      result = await descopeClient.management.outboundApplication.fetchToken(
         appId,
         userId,
-        scopes || [],
       );
+    }
 
     if (!result.ok) {
       console.error(


### PR DESCRIPTION
## Description

* Updated the extraction of authentication information in `createMcpServerHandler` to use the `auth` property instead of `authInfo` for consistency with other parts of the codebase.
* `getOutboundToken` to streamline token fetching: now conditionally calls either `fetchTokenByScopes` or `fetchToken` based on whether scopes are provided