### PR TITLE
feat: Allow Returning of client secret

### DIFF
--- a/src/handlers/register.test.ts
+++ b/src/handlers/register.test.ts
@@ -65,6 +65,7 @@ describe("registrationHandler", () => {
 
       const clientInfo = response.body;
       expect(clientInfo).toHaveProperty("client_id", "test-client-id");
+      expect(clientInfo).toHaveProperty("client_secret", "test-secret");
       expect(clientInfo).toHaveProperty(
         "client_name",
         validClientMetadata.client_name,
@@ -86,6 +87,32 @@ describe("registrationHandler", () => {
       expect(mockFetch.mock.calls[1][0]).toBe(
         "https://api.descope.com/v1/mgmt/thirdparty/app/load?id=test-app-id",
       );
+    });
+
+    it("should not include client_secret when cleartext is absent", async () => {
+      mockFetch.mockReset();
+
+      // Create response without cleartext
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: "test-app-id" }),
+        }),
+      );
+
+      mockFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ clientId: "test-client-id" }),
+        }),
+      );
+
+      const response = await request(app)
+        .post("/")
+        .send(validClientMetadata)
+        .expect(201);
+
+      expect(response.body).not.toHaveProperty("client_secret");
     });
   });
 

--- a/src/handlers/register.test.ts
+++ b/src/handlers/register.test.ts
@@ -65,7 +65,7 @@ describe("registrationHandler", () => {
 
       const clientInfo = response.body;
       expect(clientInfo).toHaveProperty("client_id", "test-client-id");
-      expect(clientInfo).toHaveProperty("client_secret", "test-secret");
+      expect(clientInfo).toHaveProperty("cleartext", "cleartext");
       expect(clientInfo).toHaveProperty(
         "client_name",
         validClientMetadata.client_name,
@@ -89,7 +89,7 @@ describe("registrationHandler", () => {
       );
     });
 
-    it("should not include client_secret when cleartext is absent", async () => {
+    it("should not include client secret when cleartext field is absent", async () => {
       mockFetch.mockReset();
 
       // Create response without cleartext
@@ -112,7 +112,7 @@ describe("registrationHandler", () => {
         .send(validClientMetadata)
         .expect(201);
 
-      expect(response.body).not.toHaveProperty("client_secret");
+      expect(response.body).not.toHaveProperty("cleartext");
     });
   });
 

--- a/src/handlers/register.test.ts
+++ b/src/handlers/register.test.ts
@@ -65,7 +65,7 @@ describe("registrationHandler", () => {
 
       const clientInfo = response.body;
       expect(clientInfo).toHaveProperty("client_id", "test-client-id");
-      expect(clientInfo).toHaveProperty("cleartext", "cleartext");
+      expect(clientInfo).toHaveProperty("client_secret", "test-secret");
       expect(clientInfo).toHaveProperty(
         "client_name",
         validClientMetadata.client_name,
@@ -89,7 +89,7 @@ describe("registrationHandler", () => {
       );
     });
 
-    it("should not include client secret when cleartext field is absent", async () => {
+    it("should not include client_secret when cleartext is absent", async () => {
       mockFetch.mockReset();
 
       // Create response without cleartext
@@ -112,7 +112,7 @@ describe("registrationHandler", () => {
         .send(validClientMetadata)
         .expect(201);
 
-      expect(response.body).not.toHaveProperty("cleartext");
+      expect(response.body).not.toHaveProperty("client_secret");
     });
   });
 

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -133,6 +133,7 @@ async function registerClient(
   const createAppResponseJson =
     (await createAppResponse.json()) as CreateAppResponse;
   const appId = createAppResponseJson.id;
+  const client_secret = createAppResponseJson.cleartext || undefined;
 
   const loadAppResponse = await fetch(
     `${provider.baseUrl}/v1/mgmt/thirdparty/app/load?id=${appId}`,
@@ -162,6 +163,7 @@ async function registerClient(
 
   return OAuthClientInformationFullSchema.parse({
     client_id,
+    client_secret,
     ...client,
   });
 }

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -133,7 +133,7 @@ async function registerClient(
   const createAppResponseJson =
     (await createAppResponse.json()) as CreateAppResponse;
   const appId = createAppResponseJson.id;
-  const cleartext = createAppResponseJson.cleartext || undefined;
+  const client_secret = createAppResponseJson.cleartext || undefined;
 
   const loadAppResponse = await fetch(
     `${provider.baseUrl}/v1/mgmt/thirdparty/app/load?id=${appId}`,
@@ -163,7 +163,7 @@ async function registerClient(
 
   return OAuthClientInformationFullSchema.parse({
     client_id,
-    cleartext,
+    client_secret,
     ...client,
   });
 }

--- a/src/handlers/register.ts
+++ b/src/handlers/register.ts
@@ -133,7 +133,7 @@ async function registerClient(
   const createAppResponseJson =
     (await createAppResponse.json()) as CreateAppResponse;
   const appId = createAppResponseJson.id;
-  const client_secret = createAppResponseJson.cleartext || undefined;
+  const cleartext = createAppResponseJson.cleartext || undefined;
 
   const loadAppResponse = await fetch(
     `${provider.baseUrl}/v1/mgmt/thirdparty/app/load?id=${appId}`,
@@ -163,7 +163,7 @@ async function registerClient(
 
   return OAuthClientInformationFullSchema.parse({
     client_id,
-    client_secret,
+    cleartext,
     ...client,
   });
 }


### PR DESCRIPTION
## Related Issues

Fixes [https://github.com/descope/etc/issues/16023](https://github.com/descope/etc/issues/16023)

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

In the Legacy Registration Process for MCP, the client secret was originally not exposed as specified in RFC 7591. This brings the SDK into alignment with the RFC.

## Must

- [x] Tests
- [x] Testing: Build examples locally and run them. Make a new MCP server in console, enable DCR for inbound apps, make a new management key to test that `client_secret` field is now populated.
- [ ] Documentation (if applicable)
