### PR TITLE
chore: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "mcp",
     "modelcontextprotocol"
   ],
+  "homepage": "https://github.com/descope/mcp-express#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/descope/mcp-express.git"
+  },
+  "bugs": {
+    "url": "https://github.com/descope/mcp-express/issues"
+  },
   "author": "Descope (https://descope.com)",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add homepage, repository, and bugs metadata for the @descope/mcp-express npm package.
- Point npm users to the package README and public issue tracker.

## Validation
- Metadata smoke check for homepage/repository/bugs fields
- npm pack --dry-run --ignore-scripts .
- git diff --check